### PR TITLE
Pkg logger

### DIFF
--- a/go-logs-go.go
+++ b/go-logs-go.go
@@ -390,7 +390,7 @@ type Logger struct {
 }
 
 // New returns a new root Logger
-func New(logConfig *RootLogConfig) *Logger {
+func New(logConfig *RootLogConfig) Logger {
 	if logConfig == nil {
 		logConfig = &RootLogConfig{}
 	}
@@ -410,7 +410,7 @@ func New(logConfig *RootLogConfig) *Logger {
 		logConfig.LogHandler = DefaultLogHandler
 	}
 
-	logger := &Logger{
+	logger := Logger{
 		parent: nil,
 		logConfig: &LogConfig{
 			Loggers: logConfig.Loggers,
@@ -435,7 +435,7 @@ func (logger *Logger) Label() string {
 // ChildLogger returns a Logger that takes it's configuration from the Logger it was created
 // from. ChildLogger's are named so that configuration can be applied specifically to them.
 // The name of a ChildLogger is also used in it's label along with it's parent's label.
-func (logger *Logger) ChildLogger(name string) *Logger {
+func (logger *Logger) ChildLogger(name string) Logger {
 	if len(name) < 1 {
 		panic(fmt.Errorf("Child loggers require a name"))
 	}
@@ -476,7 +476,7 @@ func (logger *Logger) ChildLogger(name string) *Logger {
 		logger.children[name] = child
 	}
 
-	return &child
+	return child
 }
 
 // PackageLogger returns a ChildLogger using the basename of the package path of the
@@ -487,7 +487,7 @@ func (logger *Logger) ChildLogger(name string) *Logger {
 // the actual package name (see https://golang.org/pkg/runtime/#example_Frames), but
 // for well-named packages (see https://blog.golang.org/package-names) should be the
 // same.
-func (logger *Logger) PackageLogger() *Logger {
+func (logger *Logger) PackageLogger() Logger {
 	// get the package of the caller...
 	// https://golang.org/pkg/runtime/#example_Frames
 

--- a/go-logs-go.go
+++ b/go-logs-go.go
@@ -444,7 +444,6 @@ func (logger *Logger) ChildLogger(name string) *Logger {
 
 	if strings.Contains(name, ".") {
 		parts := strings.SplitN(name, ".", 2)
-		fmt.Println(fmt.Sprintf("Debugging Parts: %s", parts))
 		parent := logger.ChildLogger(parts[0])
 		return parent.ChildLogger(parts[1])
 	}

--- a/go-logs-go_test.go
+++ b/go-logs-go_test.go
@@ -144,6 +144,11 @@ func TestConfigB(test *testing.T) {
 	if testChildLogger.Level() != logs.Debug {
 		test.Error("Expected log level to be DEBUG for `main.test`")
 	}
+
+	testChildLogger2 := rootLogger.ChildLogger("main.test")
+	if testChildLogger != testChildLogger2 {
+		test.Error("Expected `main.test` logger to be cached and retrievable")
+	}
 }
 
 func TestEnvPrefixConfig(test *testing.T) {

--- a/go-logs-go_test.go
+++ b/go-logs-go_test.go
@@ -197,3 +197,33 @@ func TestEnvPrefixConfig(test *testing.T) {
 		test.Error("Expected log level to be ERROR for `main.jsonChild.grandchild`")
 	}
 }
+
+// TestPackageLogger will test that config is honored for a PackageLogger.
+func TestPackageLogger(test *testing.T) {
+	jsonCfg, err := logs.JsonConfig([]byte(`
+	{ "level": "INFO",
+	  "loggers": {
+        "go-logs-go_test": {
+          "level": "DEBUG"
+        }
+      }
+	}
+`))
+	if nil != err {
+		test.Errorf("Error preparing RootLogConfig with logging.JsonConfig(): %s", err)
+	}
+	logger := logs.New(jsonCfg)
+
+	if logger.Level() != logs.Info {
+		test.Error("Expected log level to be INFO for `main`")
+	}
+
+	pkglogger := logger.PackageLogger()
+	if pkglogger.Level() != logs.Debug {
+		test.Errorf("Expected log level to be DEBUG (%v) for package logger. Found: %v", logs.Debug, pkglogger.Level())
+	}
+
+	if pkglogger.Label() != "go-logs-go_test" {
+		test.Errorf("Expected log label to be go-logs-go_test for package logger. Found: %v", pkglogger.Label())
+	}
+}


### PR DESCRIPTION
This ensures we don't create duplicate loggers that just have to be garbage collected, adds a `PackageLogger()` that names the logger for the base name of the package import path(!!! not package name if you've let those 2 things vary!), and returns pointers to Loggers rather than loggers. This PR supports https://github.com/big-squid/kraken-api/pull/1140.